### PR TITLE
Make visibility `pub(crate)` by default

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ouroboros_examples"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Joshua Maros <joshua-maros@github.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -34,3 +34,12 @@ pub struct DocumentationExample {
     #[borrows(mut float_data)]
     float_reference: &'this mut f32,
 }
+
+#[self_referencing(no_doc)]
+/// This struct is created using `#[self_referencing(no_doc)]` so the generated methods and 
+/// builders are hidden from documentation.
+pub struct Undocumented {
+    data: Box<i32>,
+    #[borrows(data)]
+    data_ref: &'this i32,
+}

--- a/examples/src/ok_tests.rs
+++ b/examples/src/ok_tests.rs
@@ -16,6 +16,15 @@ struct BoxAndMutRef {
     dref: &'this mut i32,
 }
 
+#[self_referencing(chain_hack, no_doc)]
+struct ChainedAndUndocumented {
+    data: Box<i32>,
+    #[borrows(data)]
+    ref1: Box<&'this i32>,
+    #[borrows(data)]
+    ref2: &'this &'this i32
+}
+
 #[test]
 fn box_and_ref() {
     let bar = BoxAndRefBuilder {

--- a/ouroboros/Cargo.toml
+++ b/ouroboros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ouroboros"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Joshua Maros <joshua-maros@github.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/ouroboros/src/lib.rs
+++ b/ouroboros/src/lib.rs
@@ -135,8 +135,9 @@
 /// The `#[self_referencing]` struct will replace your definition with an unsafe self-referencing
 /// struct with a safe public interface. Many functions will be generated depending on your original
 /// struct definition. Documentation is generated for all items, so building documentation for
-/// your project allows accessing detailed information about available functions. The following
-/// is an overview of what is generated:
+/// your project allows accessing detailed information about available functions. Using 
+/// `#[self_referencing(no_doc)]` will hide the generated items from documentation if it is becoming 
+/// too cluttered. The following is an overview of what is generated:
 /// ### `MyStruct::new(fields...) -> MyStruct`
 /// A basic constructor. It accepts values for each field in the order you declared them in. For
 /// **head fields**, you only need to pass in what value it should have and it will be moved in

--- a/ouroboros_macro/Cargo.toml
+++ b/ouroboros_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ouroboros_macro"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Joshua Maros <joshua-maros@github.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I do not believe that it makes sense to export all these fields by
default, as it clutters the documentation (especially when you add
custom accessors on top of the ouroboros provided ones). I do not know
if this is the ideal solution, but this means that I can selectively
export the builders and have all default functions inside of the
`#[self_referential]` struct be `pub(crate)` rather than `pub`.

I do not yet believe this PR is complete, and am looking for feedback.
Perhaps having all the functions be hidden from documentation generation
is a better idea?