### PR TITLE
Avoid `regex` dependency from `Inflector`

### DIFF
--- a/ouroboros_macro/Cargo.toml
+++ b/ouroboros_macro/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/joshua-maros/ouroboros"
 proc-macro = true
 
 [dependencies]
-Inflector = "0.11"
+Inflector = { version = "0.11", default-features = false }
 proc-macro2 = "1.0"
 proc-macro-error = "1.0.4"
 quote = "1.0"

--- a/ouroboros_macro/src/lib.rs
+++ b/ouroboros_macro/src/lib.rs
@@ -1719,10 +1719,11 @@ fn to_class_case(s: &str) -> String {
         .flat_map(|word| {
             let mut chars = word.chars();
             let first = chars.next();
+            // Unicode allows for a single character to become multiple characters when converting between cases.
             first
                 .into_iter()
-                .map(|c| c.to_ascii_uppercase())
-                .chain(chars.map(|c| c.to_ascii_lowercase()))
+                .flat_map(|c| c.to_uppercase())
+                .chain(chars.flat_map(|c| c.to_lowercase()))
         })
         .collect()
 }

--- a/ouroboros_macro/src/lib.rs
+++ b/ouroboros_macro/src/lib.rs
@@ -735,7 +735,7 @@ fn create_builder_and_constructor(
                 code.push(quote! { let #field_name = #builder_name (#(#builder_args),*); });
             }
             let generic_type_name =
-                format_ident!("{}Builder_", field_name.to_string().to_class_case());
+                format_ident!("{}Builder_", to_class_case(field_name.to_string().as_str()));
 
             builder_struct_generic_producers.push(quote! { #generic_type_name: #bound_type });
             builder_struct_generic_consumers.push(quote! { #generic_type_name });
@@ -973,7 +973,7 @@ fn create_try_builder_and_constructor(
                 };
             });
             let generic_type_name =
-                format_ident!("{}Builder_", field_name.to_string().to_class_case());
+                format_ident!("{}Builder_", to_class_case(field_name.to_string().as_str()));
 
             builder_struct_generic_producers.push(quote! { #generic_type_name: #bound_type });
             builder_struct_generic_consumers.push(quote! { #generic_type_name });
@@ -1710,4 +1710,19 @@ pub fn self_referencing(attr: TokenStream, item: TokenStream) -> TokenStream {
         Ok(content) => content,
         Err(err) => err.to_compile_error().into(),
     }
+}
+
+/// Functionality inspired by `Inflector`, reimplemented here to avoid the
+/// `regex` dependency.
+fn to_class_case(s: &str) -> String {
+    s.split('_')
+        .flat_map(|word| {
+            let mut chars = word.chars();
+            let first = chars.next();
+            first
+                .into_iter()
+                .map(|c| c.to_ascii_uppercase())
+                .chain(chars.map(|c| c.to_ascii_lowercase()))
+        })
+        .collect()
 }


### PR DESCRIPTION
By default, the `Inflector` crate has its `heavyweight` feature turned on, which pulls in `regex`. This is quite a heavy dependency, so downstream users can often benefit by avoiding it. This PR turns that feature off and reimplements one piece of functionality lost due to that.
