### PR TITLE
add extern crate declaration for backwards compatibility

### DIFF
--- a/ouroboros_macro/src/lib.rs
+++ b/ouroboros_macro/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate proc_macro;
+
 use inflector::Inflector;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;


### PR DESCRIPTION
`extern crate proc_macro;` is no longer needed since rust 1.42, however I'm currently trying to use ouroboros in https://github.com/uutils/coreutils, which has a MinRustV policy of 1.40 (i.e. code has to compile for at least rust 1.40).

By adding this declaration `ouroboros` can compile with rust version 1.40.