### PR TITLE
Fix readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Easy self-referential struct generation for Rust.
 Dual licensed under MIT / Apache 2.0.
 
 Note: Version `0.7.0` removed the `with_*_contents` and `borrow_*_contents` functions, replacing
-them with `with_*` and `borrows_*` functions that work similar to functions with those names in 
-earlier versions. In other words, there is no longer seperate semantics for accessing tail fields
+them with `with_*` and `borrow_*` functions that work similar to functions with those names in 
+earlier versions. In other words, there is no longer separate semantics for accessing tail fields
 and immutably borrowed fields. See the documentation for a full explanation.
 
 Note: as of September 2020, there is a [limitation in Rust's type checker](https://users.rust-lang.org/t/why-does-this-not-compile-box-t-target-t/49027/7?u=aaaaa)


### PR DESCRIPTION
Fixes typo that hung me up when bumping our version, and another inconsequential one I happened to notice while in there.