### PR TITLE
Forego aliased in check fn

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -30,7 +30,6 @@ pub struct DocumentationExample {
     #[borrows(int_data)]
     int_reference: &'this i32,
     #[borrows(mut float_data)]
-    #[not_covariant]
     float_reference: &'this mut f32,
 }
 

--- a/examples/src/ok_tests.rs
+++ b/examples/src/ok_tests.rs
@@ -7,7 +7,6 @@ use std::fmt::Debug;
 struct TraitObject {
     data: Box<dyn Debug>,
     #[borrows(data)]
-    #[covariant]
     dref: &'this dyn Debug,
 }
 
@@ -22,7 +21,6 @@ struct BoxAndRef {
 struct BoxAndMutRef {
     data: i32,
     #[borrows(mut data)]
-    #[not_covariant]
     dref: &'this mut i32,
 }
 
@@ -39,7 +37,6 @@ struct ChainedAndUndocumented {
 struct BoxCheckWithLifetimeParameter<'t> {
     external_data: &'t (),
     #[borrows(external_data)]
-    #[covariant]
     self_reference: &'this &'t (),
 }
 
@@ -67,7 +64,6 @@ where
     data2: &'this C,
     data3: B,
     #[borrows(mut data3)]
-    #[not_covariant]
     data4: &'this mut C,
 }
 

--- a/ouroboros_macro/src/generate/mod.rs
+++ b/ouroboros_macro/src/generate/mod.rs
@@ -2,7 +2,7 @@ pub mod constructor;
 pub mod derives;
 pub mod into_heads;
 pub mod struc;
-pub mod summon_borrowchk;
+pub mod summon_checker;
 pub mod try_constructor;
 pub mod type_asserts;
 pub mod with_all;

--- a/ouroboros_macro/src/lib.rs
+++ b/ouroboros_macro/src/lib.rs
@@ -10,7 +10,7 @@ use crate::{
     generate::{
         constructor::create_builder_and_constructor, derives::create_derives,
         into_heads::make_into_heads, struc::create_actual_struct_def,
-        summon_borrowchk::generate_borrowchk_summoner,
+        summon_checker::generate_checker_summoner,
         try_constructor::create_try_builder_and_constructor, type_asserts::make_type_asserts,
         with_all::make_with_all_function, with_each::make_with_functions,
     },
@@ -37,7 +37,7 @@ fn self_referencing_impl(
 
     let actual_struct_def = create_actual_struct_def(&info)?;
 
-    let borrowchk_summoner = generate_borrowchk_summoner(&info)?;
+    let borrowchk_summoner = generate_checker_summoner(&info)?;
 
     let (builder_struct_name, builder_def, constructor_def) =
         create_builder_and_constructor(&info, options, false)?;


### PR DESCRIPTION
Get rid of aliased boxes in the check function.

Accidentally did it based on #44 so check the commits to see only the new changes.