### PR TITLE
Suppress missing docs warning

### DIFF
--- a/ouroboros_macro/src/lib.rs
+++ b/ouroboros_macro/src/lib.rs
@@ -71,6 +71,7 @@ fn self_referencing_impl(
         #[doc="Encapsulates implementation details for a self-referencing struct. This module is only visible when using --document-private-items."]
         mod #mod_name {
             use super::*;
+            #[doc="The self-referencing struct."]
             #actual_struct_def
             #borrowchk_summoner
             #builder_def


### PR DESCRIPTION
Hi, there. This PR aims to suppress missing docs warning of Rust linter while using `#[ouroboros::self_referencing]` with `#![warn(missing_docs)]` enabled.

E.g. https://github.com/SeaQL/sea-orm/runs/4076651605
```
missing documentation for a struct
warning: missing documentation for a struct
  --> src/database/stream/transaction.rs:14:1
   |
14 | #[ouroboros::self_referencing]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this warning originates in the attribute macro `ouroboros::self_referencing` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Thanks!!