### PR TITLE
Added some extra comments in the first example code for the TLDR crowd

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,56 +20,56 @@ Version notes:
 Tests are located in the examples/ folder because they need to be in a crate
 outside of `ouroboros` for the `self_referencing` macro to work properly.
 
-/// ```rust
-/// use ouroboros::self_referencing;
-///
-/// #[self_referencing]
-/// struct MyStruct {
-///     int_data: i32,
-///     float_data: f32,
-///     #[borrows(int_data)]
-///     // the 'this lifetime is created by the #[self_referencing] macro
-///     // and should be used on all references marked by the #[borrows] macro
-///     int_reference: &'this i32,
-///     #[borrows(mut float_data)]
-///     float_reference: &'this mut f32,
-/// }
-///
-/// fn main() {
-///     // The builder is created by the #[self_referencing] macro 
-///     // and is used to create the struct
-///     let mut my_value = MyStructBuilder {
-///         int_data: 42,
-///         float_data: 3.14,
-///
-///         // Note that the name of the field in the builder 
-///         // is the name of the field in the struct + `_builder` 
-///         // ie: {field_name}_builder
-///         // the closure that assigns the value for the field will be passed 
-///         // a reference to the field(s) defined in the #[borrows] macro
-///	
-///         int_reference_builder: |int_data: &i32| int_data,
-///         float_reference_builder: |float_data: &mut f32| float_data,
-///     }.build();
-///
-///     // The fields in the original struct can not be accesed directly
-///     // The builder creates accessor methods which are called borrow_{field_name}()
-///
-///     // Prints 42
-///     println!("{:?}", my_value.borrow_int_data());
-///     // Prints 3.14
-///     println!("{:?}", my_value.borrow_float_reference());
-///     // Sets the value of float_data to 84.0
-///     my_value.with_mut(|fields| {
-///         **fields.float_reference = (**fields.int_reference as f32) * 2.0;
-///     });
-///
-///     // We can hold on to this reference...
-///     let int_ref = *my_value.borrow_int_reference();
-///     println!("{:?}", *int_ref);
-///     // As long as the struct is still alive.
-///     drop(my_value);
-///     // This will cause an error!
-///     // println!("{:?}", *int_ref);
-/// }
-/// ```
+```rust
+use ouroboros::self_referencing;
+
+#[self_referencing]
+struct MyStruct {
+    int_data: i32,
+    float_data: f32,
+    #[borrows(int_data)]
+    // the 'this lifetime is created by the #[self_referencing] macro
+    // and should be used on all references marked by the #[borrows] macro
+    int_reference: &'this i32,
+    #[borrows(mut float_data)]
+    float_reference: &'this mut f32,
+}
+
+fn main() {
+    // The builder is created by the #[self_referencing] macro 
+    // and is used to create the struct
+    let mut my_value = MyStructBuilder {
+        int_data: 42,
+        float_data: 3.14,
+
+        // Note that the name of the field in the builder 
+        // is the name of the field in the struct + `_builder` 
+        // ie: {field_name}_builder
+        // the closure that assigns the value for the field will be passed 
+        // a reference to the field(s) defined in the #[borrows] macro
+	
+        int_reference_builder: |int_data: &i32| int_data,
+        float_reference_builder: |float_data: &mut f32| float_data,
+    }.build();
+
+    // The fields in the original struct can not be accesed directly
+    // The builder creates accessor methods which are called borrow_{field_name}()
+
+    // Prints 42
+    println!("{:?}", my_value.borrow_int_data());
+    // Prints 3.14
+    println!("{:?}", my_value.borrow_float_reference());
+    // Sets the value of float_data to 84.0
+    my_value.with_mut(|fields| {
+        **fields.float_reference = (**fields.int_reference as f32) * 2.0;
+    });
+
+    // We can hold on to this reference...
+    let int_ref = *my_value.borrow_int_reference();
+    println!("{:?}", *int_ref);
+    // As long as the struct is still alive.
+    drop(my_value);
+    // This will cause an error!
+    // println!("{:?}", *int_ref);
+}
+```

--- a/README.md
+++ b/README.md
@@ -20,42 +20,56 @@ Version notes:
 Tests are located in the examples/ folder because they need to be in a crate
 outside of `ouroboros` for the `self_referencing` macro to work properly.
 
-```rust
-use ouroboros::self_referencing;
-
-#[self_referencing]
-struct MyStruct {
-    int_data: i32,
-    float_data: f32,
-    #[borrows(int_data)]
-    int_reference: &'this i32,
-    #[borrows(mut float_data)]
-    float_reference: &'this mut f32,
-}
-
-fn main() {
-    let mut my_value = MyStructBuilder {
-        int_data: 42,
-        float_data: 3.14,
-        int_reference_builder: |int_data: &i32| int_data,
-        float_reference_builder: |float_data: &mut f32| float_data,
-    }.build();
-
-    // Prints 42
-    println!("{:?}", my_value.borrow_int_data());
-    // Prints 3.14
-    println!("{:?}", my_value.borrow_float_reference());
-    // Sets the value of float_data to 84.0
-    my_value.with_mut(|fields| {
-        **fields.float_reference = (**fields.int_reference as f32) * 2.0;
-    });
-
-    // We can hold on to this reference...
-    let int_ref = *my_value.borrow_int_reference();
-    println!("{:?}", *int_ref);
-    // As long as the struct is still alive.
-    drop(my_value);
-    // This will cause an error!
-    // println!("{:?}", *int_ref);
-}
-```
+/// ```rust
+/// use ouroboros::self_referencing;
+///
+/// #[self_referencing]
+/// struct MyStruct {
+///     int_data: i32,
+///     float_data: f32,
+///     #[borrows(int_data)]
+///     // the 'this lifetime is created by the #[self_referencing] macro
+///     // and should be used on all references marked by the #[borrows] macro
+///     int_reference: &'this i32,
+///     #[borrows(mut float_data)]
+///     float_reference: &'this mut f32,
+/// }
+///
+/// fn main() {
+///     // The builder is created by the #[self_referencing] macro 
+///     // and is used to create the struct
+///     let mut my_value = MyStructBuilder {
+///         int_data: 42,
+///         float_data: 3.14,
+///
+///         // Note that the name of the field in the builder 
+///         // is the name of the field in the struct + `_builder` 
+///         // ie: {field_name}_builder
+///         // the closure that assigns the value for the field will be passed 
+///         // a reference to the field(s) defined in the #[borrows] macro
+///	
+///         int_reference_builder: |int_data: &i32| int_data,
+///         float_reference_builder: |float_data: &mut f32| float_data,
+///     }.build();
+///
+///     // The fields in the original struct can not be accesed directly
+///     // The builder creates accessor methods which are called borrow_{field_name}()
+///
+///     // Prints 42
+///     println!("{:?}", my_value.borrow_int_data());
+///     // Prints 3.14
+///     println!("{:?}", my_value.borrow_float_reference());
+///     // Sets the value of float_data to 84.0
+///     my_value.with_mut(|fields| {
+///         **fields.float_reference = (**fields.int_reference as f32) * 2.0;
+///     });
+///
+///     // We can hold on to this reference...
+///     let int_ref = *my_value.borrow_int_reference();
+///     println!("{:?}", *int_ref);
+///     // As long as the struct is still alive.
+///     drop(my_value);
+///     // This will cause an error!
+///     // println!("{:?}", *int_ref);
+/// }
+/// ```

--- a/ouroboros/src/lib.rs
+++ b/ouroboros/src/lib.rs
@@ -14,18 +14,32 @@
 ///     int_data: i32,
 ///     float_data: f32,
 ///     #[borrows(int_data)]
+///     // the 'this lifetime is created by the #[self_referencing] macro
+///     // and should be used on all references marked by the #[borrows] macro
 ///     int_reference: &'this i32,
 ///     #[borrows(mut float_data)]
 ///     float_reference: &'this mut f32,
 /// }
 ///
 /// fn main() {
+///     // The builder is created by the #[self_referencing] macro 
+///     // and is used to create the struct
 ///     let mut my_value = MyStructBuilder {
 ///         int_data: 42,
 ///         float_data: 3.14,
+///
+///         // Note that the name of the field in the builder 
+///         // is the name of the field in the struct + `_builder` 
+///         // ie: {field_name}_builder
+///         // the closure that assigns the value for the field will be passed 
+///         // a reference to the field(s) defined in the #[borrows] macro
+///	
 ///         int_reference_builder: |int_data: &i32| int_data,
 ///         float_reference_builder: |float_data: &mut f32| float_data,
 ///     }.build();
+///
+///     // The fields in the original struct can not be accesed directly
+///     // The builder creates accessor methods which are called borrow_{field_name}()
 ///
 ///     // Prints 42
 ///     println!("{:?}", my_value.borrow_int_data());


### PR DESCRIPTION
Hi, 

I just started using ouroboros yesterday and thought it would be useful to add some comments to the example to make it easier to understand how the crate works at a glance especially for the TLDR crowd (myself included).

The documentation at the end of the lib.rs file explains well what the crate/macro does but is placed after the more complex Async example. I confess I stopped reading when I saw the complex example and just assumed that the rest was complex.  Maybe it would also be a good idea to put the documentation up higher. 

Also, I had seen/heard of the crate before but it was not initially obvious to me that I needed to use it for my use case. <https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=1003faaa432176a16d2422532d9b97a0>

It could be a good idea to say a bit more background about what the limitations of Rust are regarding self referential structs, and typical error messages. For example It wasn't obvious to me that I couldn't have a struct containing a  Box<[u8]> and a struct referencing the slice in the box, and that I could solve the problem with your crate.

Its my first PR request so I hope its OK.

Thanks for the crate it solved the problem I had :)

