### PR TITLE
Remove stable_deref_trait dependency

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,7 +20,6 @@ miri = []
 
 [dependencies]
 ouroboros = { version = "0.15.0", path = "../ouroboros" }
-stable_deref_trait = "1.2"
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/examples/src/fail_tests/refuse_non_std_box.rs
+++ b/examples/src/fail_tests/refuse_non_std_box.rs
@@ -16,8 +16,6 @@ impl<T> Deref for Box<T> {
     }
 }
 
-unsafe impl<T> stable_deref_trait::StableDeref for Box<T> {}
-
 #[self_referencing]
 struct Simple {
     data: Box<String>,

--- a/examples/src/fail_tests/refuse_non_std_box.stderr
+++ b/examples/src/fail_tests/refuse_non_std_box.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no function or associated item named `is_std_box_type` found for struct `CheckIfTypeIsStd<Box<String>>` in the current scope
-  --> $DIR/refuse_non_std_box.rs:21:1
+  --> $DIR/refuse_non_std_box.rs:19:1
    |
-21 | #[self_referencing]
+19 | #[self_referencing]
    | ^^^^^^^^^^^^^^^^^^^ function or associated item not found in `CheckIfTypeIsStd<Box<String>>`
    |
    = note: the function or associated item was found for

--- a/ouroboros/Cargo.toml
+++ b/ouroboros/Cargo.toml
@@ -12,4 +12,3 @@ repository = "https://github.com/joshua-maros/ouroboros"
 [dependencies]
 aliasable = "0.1.3"
 ouroboros_macro = { version = "0.15.0", path = "../ouroboros_macro" }
-stable_deref_trait = "1.2"


### PR DESCRIPTION
Now that AliasableBox is used everywhere, it's not actually used.