### PR TITLE
Inline with_* and borrow_* methods

### DIFF
--- a/ouroboros_macro/src/generate/with_all.rs
+++ b/ouroboros_macro/src/generate/with_all.rs
@@ -110,6 +110,7 @@ pub fn make_with_all_function(
     };
     let fn_defs = quote! {
         #documentation
+        #[inline(always)]
         #visibility fn with <'outer_borrow, ReturnType>(
             &'outer_borrow self,
             user: impl for<'this> ::core::ops::FnOnce(#borrowed_fields_type) -> ReturnType
@@ -119,6 +120,7 @@ pub fn make_with_all_function(
             })
         }
         #mut_documentation
+        #[inline(always)]
         #visibility fn with_mut <'outer_borrow, ReturnType>(
             &'outer_borrow mut self,
             user: impl for<'this> ::core::ops::FnOnce(#borrowed_mut_fields_type) -> ReturnType

--- a/ouroboros_macro/src/generate/with_each.rs
+++ b/ouroboros_macro/src/generate/with_each.rs
@@ -29,6 +29,7 @@ pub fn make_with_functions(info: &StructInfo, options: Options) -> Result<Vec<To
             };
             users.push(quote! {
                 #documentation
+                #[inline(always)]
                 #visibility fn #user_name <'outer_borrow, ReturnType>(
                     &'outer_borrow self,
                     user: impl for<'this> ::core::ops::FnOnce(&'outer_borrow #field_type) -> ReturnType,
@@ -40,6 +41,7 @@ pub fn make_with_functions(info: &StructInfo, options: Options) -> Result<Vec<To
                 let borrower_name = format_ident!("borrow_{}", &field.name);
                 users.push(quote! {
                     #documentation
+                    #[inline(always)]
                     #visibility fn #borrower_name<'this>(
                         &'this self,
                     ) -> &'this #field_type {
@@ -69,6 +71,7 @@ pub fn make_with_functions(info: &StructInfo, options: Options) -> Result<Vec<To
             };
             users.push(quote! {
                 #documentation
+                #[inline(always)]
                 #visibility fn #user_name <'outer_borrow, ReturnType>(
                     &'outer_borrow mut self,
                     user: impl for<'this> ::core::ops::FnOnce(&'outer_borrow mut #field_type) -> ReturnType,
@@ -94,6 +97,7 @@ pub fn make_with_functions(info: &StructInfo, options: Options) -> Result<Vec<To
             };
             users.push(quote! {
                 #documentation
+                #[inline(always)]
                 #visibility fn #user_name <'outer_borrow, ReturnType>(
                     &'outer_borrow self,
                     user: impl for<'this> ::core::ops::FnOnce(&'outer_borrow #field_type) -> ReturnType,
@@ -112,6 +116,7 @@ pub fn make_with_functions(info: &StructInfo, options: Options) -> Result<Vec<To
             let borrower_name = format_ident!("borrow_{}", &field.name);
             users.push(quote! {
                 #documentation
+                #[inline(always)]
                 #visibility fn #borrower_name<'this>(
                     &'this self,
                 ) -> &'this #field_type {


### PR DESCRIPTION
Without inlining these methods, various optimizations you normally get with field accesses are inhibited by the function call. They are marked `#[inline(always)]` here as opposed to just `#[inline]`, so that large closure bodies don't prevent the function from being inlined.