### PR TITLE
Make ouroboros `no_std` compatible.

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -20,6 +20,14 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Check under no_std
+      run: |
+        # thumbv6m-none-eabi is a Tier 2 target which has no `std` and no atomic pointers.
+        rustup target add thumbv6m-none-eabi
+        cargo check --verbose --target thumbv6m-none-eabi
+        # aarch64-unknown-none is Tier 2, has no `std`, but does have atomic pointers.
+        rustup target add aarch64-unknown-none
+        cargo check --verbose --target aarch64-unknown-none
     
   miri-test:
     runs-on: ubuntu-latest

--- a/examples/src/fail_tests/auto_covariant.stderr
+++ b/examples/src/fail_tests/auto_covariant.stderr
@@ -9,13 +9,7 @@ error: Ouroboros cannot automatically determine if this type is covariant.
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0601]: `main` function not found in crate `$CRATE`
-  --> $DIR/auto_covariant.rs:1:1
+  --> $DIR/auto_covariant.rs:12:2
    |
-1  | / use ouroboros::self_referencing;
-2  | |
-3  | | struct NotGuaranteedCovariant<'a> {
-4  | |     data: &'a (),
-...  |
-11 | |     field: NotGuaranteedCovariant<'this>
-12 | | }
-   | |_^ consider adding a `main` function to `$DIR/src/fail_tests/auto_covariant.rs`
+12 | }
+   |  ^ consider adding a `main` function to `$DIR/src/fail_tests/auto_covariant.rs`

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+extern crate alloc;
+use alloc::boxed::Box;
+
 use ouroboros::self_referencing;
 
 #[cfg(test)]

--- a/examples/src/ok_tests.rs
+++ b/examples/src/ok_tests.rs
@@ -1,5 +1,8 @@
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use core::fmt::Debug;
+
 use ouroboros::self_referencing;
-use std::fmt::Debug;
 
 // All tests here should compile and run correctly and pass Miri's safety checks.
 
@@ -208,8 +211,8 @@ fn template_mess() {
         data4_builder: |data3_contents| data3_contents,
     }
     .build();
-    instance.with_external(|ext| println!("{}", ext));
-    instance.with_data1(|data| println!("{}", *data));
+    instance.with_external(|ext| assert_eq!(*ext, "Hello World!"));
+    instance.with_data1(|data| assert_eq!(data, "asdf"));
     instance.with_data4_mut(|con| **con = "Modified".to_owned());
     instance.with(|fields| {
         assert!(**fields.data1 == **fields.data2);

--- a/ouroboros/src/lib.rs
+++ b/ouroboros/src/lib.rs
@@ -3,6 +3,7 @@
 //! See the documentation of [`ouroboros_examples`](https://docs.rs/ouroboros_examples) for
 //! sample documentation of structs which have had the macro applied to them.
 
+#![no_std]
 #![allow(clippy::needless_doctest_main)]
 
 /// This macro is used to turn a regular struct into a self-referencing one. An example:
@@ -348,10 +349,12 @@ pub use ouroboros_macro::self_referencing;
 
 #[doc(hidden)]
 pub mod macro_help {
+    pub extern crate alloc;
+
     pub use aliasable::boxed::AliasableBox;
     use aliasable::boxed::UniqueBox;
 
-    pub struct CheckIfTypeIsStd<T>(std::marker::PhantomData<T>);
+    pub struct CheckIfTypeIsStd<T>(core::marker::PhantomData<T>);
 
     macro_rules! std_type_check {
         ($fn_name:ident $T:ident $check_for:ty) => {
@@ -361,9 +364,10 @@ pub mod macro_help {
         };
     }
 
-    std_type_check!(is_std_box_type T std::boxed::Box<T>);
-    std_type_check!(is_std_arc_type T std::sync::Arc<T>);
-    std_type_check!(is_std_rc_type T std::rc::Rc<T>);
+    std_type_check!(is_std_box_type T alloc::boxed::Box<T>);
+    #[cfg(target_has_atomic = "ptr")] // alloc::sync is missing if this is false
+    std_type_check!(is_std_arc_type T alloc::sync::Arc<T>);
+    std_type_check!(is_std_rc_type T alloc::rc::Rc<T>);
 
     pub fn aliasable_boxed<T>(data: T) -> AliasableBox<T> {
         AliasableBox::from_unique(UniqueBox::new(data))

--- a/ouroboros_macro/src/generate/derives.rs
+++ b/ouroboros_macro/src/generate/derives.rs
@@ -40,10 +40,10 @@ fn impl_debug(info: &StructInfo) -> Result<TokenStream, Error> {
             }
         })
         .collect::<Vec<_>>();
-    let trait_name = syn::parse_quote! { ::std::fmt::Debug };
+    let trait_name = syn::parse_quote! { ::core::fmt::Debug };
     let struct_name = &info.ident;
     let body = quote! {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
             self.with(|safe_self| {
                 f.debug_struct(stringify!(#struct_name))
                 #(.#fields)*

--- a/ouroboros_macro/src/info_structures.rs
+++ b/ouroboros_macro/src/info_structures.rs
@@ -261,10 +261,14 @@ impl StructFieldInfo {
         let field_type = &self.typ;
         let return_ty_constructor = || match builder_type {
             BuilderType::AsyncSend => {
-                quote! { ::std::pin::Pin<::std::boxed::Box<dyn ::core::future::Future<Output=#field_type> + ::core::marker::Send + 'this>> }
+                quote! {
+                    ::core::pin::Pin<::ouroboros::macro_help::alloc::boxed::Box<
+                        dyn ::core::future::Future<Output=#field_type> + ::core::marker::Send + 'this>>
+                }
             }
             BuilderType::Async => {
-                quote! { ::std::pin::Pin<::std::boxed::Box<dyn ::core::future::Future<Output=#field_type> + 'this>> }
+                quote! { ::core::pin::Pin<::ouroboros::macro_help::alloc::boxed::Box<
+                dyn ::core::future::Future<Output=#field_type> + 'this>> }
             }
             BuilderType::Sync => quote! { #field_type },
         };
@@ -280,10 +284,18 @@ impl StructFieldInfo {
         let field_type = &self.typ;
         let return_ty_constructor = || match builder_type {
             BuilderType::AsyncSend => {
-                quote! { ::std::pin::Pin<::std::boxed::Box<dyn ::core::future::Future<Output=::core::result::Result<#field_type, Error_>> + ::core::marker::Send + 'this>> }
+                quote! {
+                    ::core::pin::Pin<::ouroboros::macro_help::alloc::boxed::Box<
+                        dyn ::core::future::Future<Output=::core::result::Result<#field_type, Error_>>
+                            + ::core::marker::Send + 'this>>
+                }
             }
             BuilderType::Async => {
-                quote! { ::std::pin::Pin<::std::boxed::Box<dyn ::core::future::Future<Output=::core::result::Result<#field_type, Error_>> + 'this>> }
+                quote! {
+                    ::core::pin::Pin<::ouroboros::macro_help::alloc::boxed::Box<
+                        dyn ::core::future::Future<Output=::core::result::Result<#field_type, Error_>>
+                            + 'this>>
+                }
             }
             BuilderType::Sync => quote! { ::core::result::Result<#field_type, Error_> },
         };


### PR DESCRIPTION
This PR makes `ouroboros` compatible with targets which support the `alloc` crate but not the `std` crate.

* Mark the crate `#![no_std]`.
* Replace all references to `std` with `core` or `alloc`.
* Don't mention `Arc` if the target doesn't support it.
* Reexport `alloc` from `ouroboros::macro_help` so that the crate calling the macro doesn't need any `extern crate alloc`.
* Modify `examples` to compile under `no_std`.
* Add CI to try building under `no_std` targets.

This should be a non-breaking change and make no visible difference except for maybe paths in errors.