### PR TITLE
Fix compatibility with the thumbv6m-none-eabi target

### DIFF
--- a/ouroboros/src/lib.rs
+++ b/ouroboros/src/lib.rs
@@ -365,6 +365,7 @@ pub mod macro_help {
     }
 
     std_type_check!(is_std_box_type T alloc::boxed::Box<T>);
+    #[cfg(target_has_atomic = "ptr")]
     std_type_check!(is_std_arc_type T alloc::sync::Arc<T>);
     std_type_check!(is_std_rc_type T alloc::rc::Rc<T>);
 


### PR DESCRIPTION
This is a fix for https://github.com/joshua-maros/ouroboros/issues/81